### PR TITLE
allow spop can parameters

### DIFF
--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -85,7 +85,6 @@ redis_arg0(struct msg *r)
 
     case MSG_REQ_REDIS_SCARD:
     case MSG_REQ_REDIS_SMEMBERS:
-    case MSG_REQ_REDIS_SPOP:
 
     case MSG_REQ_REDIS_ZCARD:
     case MSG_REQ_REDIS_PFCOUNT:
@@ -268,6 +267,7 @@ redis_argx(struct msg *r)
     switch (r->type) {
     case MSG_REQ_REDIS_MGET:
     case MSG_REQ_REDIS_DEL:
+    case MSG_REQ_REDIS_SPOP:
         return true;
 
     default:


### PR DESCRIPTION
```
SPOP can get count parameter
This patch can allow SPOP command can get count param or not
move SPOP from redis_arg0 to redis_argx
```