### PR TITLE
move spop to use redis_argn

### DIFF
--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -234,6 +234,7 @@ redis_argn(struct msg *r)
     case MSG_REQ_REDIS_SUNIONSTORE:
     case MSG_REQ_REDIS_SRANDMEMBER:
     case MSG_REQ_REDIS_SSCAN:
+    case MSG_REQ_REDIS_SPOP:
 
     case MSG_REQ_REDIS_PFADD:
     case MSG_REQ_REDIS_PFMERGE:
@@ -267,7 +268,6 @@ redis_argx(struct msg *r)
     switch (r->type) {
     case MSG_REQ_REDIS_MGET:
     case MSG_REQ_REDIS_DEL:
-    case MSG_REQ_REDIS_SPOP:
         return true;
 
     default:


### PR DESCRIPTION
move SPOP to use redis_argn not redis_argx
redis_argn is more right for meaning.